### PR TITLE
RocketCheck.php now uses version_compare() so it correctly compares RCs

### DIFF
--- a/root/root/RocketCheck/RocketCheck.php
+++ b/root/root/RocketCheck/RocketCheck.php
@@ -53,7 +53,13 @@ if (file_exists && is_readable($inputFile)) {
 
     }
     $version    = array_unique($version);
-    $version    = max($version);
+    foreach($version as $eachVersion){
+	$VCV = version_compare($eachVersion, $highest);
+	if ($VCV == 1){
+	    $highest = $eachVersion;
+	}
+    }
+    $version = $highest;
 
     $oldVersion = readMyFile($verFile);
 


### PR DESCRIPTION
Using the max() function doesn't correctly handle version numbers when there are release candidates. I've used version_compare() which should work instead. Thanks

:-)